### PR TITLE
Add gallery view for images

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3007,6 +3007,7 @@
   "profileInfo": "Profile info",
   "saveToDownloads": "Save to Downloads",
   "saveToGallery": "Save to Gallery",
+  "showAllMedia": "Show all media",
   "fileSavedToDownloads": "File saved to Downloads",
   "saveFileToDownloadsError": "Failed to save file to Downloads",
   "explainPermissionToDownloadFiles": "To continue, please allow {appName} to access storage permission. This permission is essential for saving file to Downloads folder.",

--- a/assets/l10n/intl_ru.arb
+++ b/assets/l10n/intl_ru.arb
@@ -3048,6 +3048,7 @@
   "@phone": {},
   "saveToGallery": "Сохранить в \"Галерею\"",
   "@saveToGallery": {},
+  "showAllMedia": "Показать все медиа",
   "saveFileToGalleryError": "Не удалось сохранить файл в \"Галерею\"",
   "@saveFileToGalleryError": {},
   "copiedPublicKeyToClipboard": "Открытый ключ скопирован в буфер обмена.",

--- a/lib/pages/image_viewer/image_gallery_page.dart
+++ b/lib/pages/image_viewer/image_gallery_page.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+import 'image_viewer.dart';
+import 'media_viewer_app_bar.dart';
+
+class ImageGalleryPage extends StatefulWidget {
+  final List<Event> events;
+  final int initialIndex;
+
+  const ImageGalleryPage({
+    super.key,
+    required this.events,
+    required this.initialIndex,
+  });
+
+  @override
+  State<ImageGalleryPage> createState() => _ImageGalleryPageState();
+}
+
+class _ImageGalleryPageState extends State<ImageGalleryPage> {
+  late final PageController _pageController;
+  late int _currentIndex;
+  final ValueNotifier<bool> _showAppBar = ValueNotifier(true);
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialIndex;
+    _pageController = PageController(initialPage: _currentIndex);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    _showAppBar.dispose();
+    super.dispose();
+  }
+
+  void _onPageChanged(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  void _toggleAppBar() {
+    _showAppBar.value = !_showAppBar.value;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: GestureDetector(
+        onTap: _toggleAppBar,
+        child: Stack(
+          children: [
+            PageView.builder(
+              controller: _pageController,
+              onPageChanged: _onPageChanged,
+              itemCount: widget.events.length,
+              itemBuilder: (context, index) => ImageViewer(
+                event: widget.events[index],
+              ),
+            ),
+            MediaViewerAppBar(
+              showAppbarPreviewNotifier: _showAppBar,
+              event: widget.events[_currentIndex],
+              currentIndex: _currentIndex + 1,
+              totalCount: widget.events.length,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/image_viewer/media_viewer_app_bar.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar.dart
@@ -13,11 +13,15 @@ class MediaViewerAppBar extends StatefulWidget {
     this.showAppbarPreviewNotifier,
     this.event,
     this.enablePaddingAppbar = true,
+    this.currentIndex,
+    this.totalCount,
   });
 
   final ValueNotifier<bool>? showAppbarPreviewNotifier;
   final Event? event;
   final bool? enablePaddingAppbar;
+  final int? currentIndex;
+  final int? totalCount;
 
   static final responsiveUtils = getIt.get<ResponsiveUtils>();
 
@@ -31,6 +35,9 @@ class MediaViewerAppBarController extends State<MediaViewerAppBar>
         SaveMediaToGalleryAndroidMixin,
         MediaViewerAppBarMixin {
   ValueNotifier<bool>? showAppbarPreview;
+
+  int? get currentIndex => widget.currentIndex;
+  int? get totalCount => widget.totalCount;
 
   @override
   void initState() {

--- a/lib/pages/image_viewer/media_viewer_app_bar_view.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar_view.dart
@@ -50,6 +50,35 @@ class MediaViewerAppbarView extends StatelessWidget {
                         color: LinagoraSysColors.material().onPrimary,
                         tooltip: L10n.of(context)!.back,
                       ),
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (controller.widget.event != null)
+                            Text(
+                              controller.widget.event!.originServerTs
+                                  .localizedTime(context),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(
+                                    color: LinagoraSysColors.material()
+                                        .onPrimary,
+                                  ),
+                            ),
+                          if (controller.currentIndex != null &&
+                              controller.totalCount != null)
+                            Text(
+                              '${controller.currentIndex} of ${controller.totalCount}',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(
+                                    color: LinagoraSysColors.material()
+                                        .onPrimary,
+                                  ),
+                            ),
+                        ],
+                      ),
                       Row(
                         children: [
                           if (PlatformInfos.isMobile)
@@ -121,9 +150,34 @@ class MediaViewerAppbarView extends StatelessWidget {
                                       },
                                     ),
                                     ContextMenuItemImageViewer(
+                                      title: L10n.of(context)!.showAllMedia,
+                                      icon: Icons.photo_library_outlined,
+                                      onTap: () => controller.openAllMedia(
+                                        context,
+                                        controller.widget.event,
+                                      ),
+                                    ),
+                                    ContextMenuItemImageViewer(
                                       title: L10n.of(context)!.showInChat,
                                       imagePath: ImagePaths.icShowInChat,
                                       onTap: () => controller.showInChat(
+                                        context,
+                                        controller.widget.event,
+                                      ),
+                                      haveDivider: false,
+                                    ),
+                                    ContextMenuItemImageViewer(
+                                      icon: Icons.share,
+                                      title: L10n.of(context)!.share,
+                                      onTap: () => controller.shareFileAction(
+                                        context,
+                                        controller.widget.event,
+                                      ),
+                                    ),
+                                    ContextMenuItemImageViewer(
+                                      icon: Icons.delete_outline,
+                                      title: L10n.of(context)!.delete,
+                                      onTap: () => controller.deleteEvent(
                                         context,
                                         controller.widget.event,
                                       ),

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:fluffychat/pages/image_viewer/image_viewer.dart';
+import 'package:fluffychat/pages/image_viewer/image_gallery_page.dart';
 import 'package:fluffychat/presentation/enum/chat/media_viewer_popup_result_enum.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/utils/extension/mime_type_extension.dart';
-import 'package:fluffychat/utils/interactive_viewer_gallery.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
@@ -236,14 +236,20 @@ class _MxcImageState extends State<MxcImage> {
   void _onTap(BuildContext context) async {
     if (widget.onTapPreview != null) {
       widget.onTapPreview!();
-      final result =
-          await Navigator.of(context, rootNavigator: PlatformInfos.isWeb).push(
+      final roomEvents = widget.event!.room.timeline.events
+          .where((e) => e.messageType == MessageTypes.Image)
+          .toList();
+      final initial =
+          roomEvents.indexWhere((e) => e.eventId == widget.event!.eventId);
+      final result = await Navigator.of(
+        context,
+        rootNavigator: PlatformInfos.isWeb,
+      ).push(
         HeroPageRoute(
           builder: (context) {
-            return InteractiveViewerGallery(
-              itemBuilder: ImageViewer(
-                event: widget.event!,
-              ),
+            return ImageGalleryPage(
+              events: roomEvents,
+              initialIndex: initial < 0 ? 0 : initial,
             );
           },
         ),


### PR DESCRIPTION
## Summary
- create `ImageGalleryPage` to swipe through chat images
- show date/time and counter in `MediaViewerAppBar`
- extend image viewer menu with share, delete, and show all media actions
- add ability to open media list and delete from `MediaViewerAppBarMixin`
- open gallery from `MxcImage` tap
- update English and Russian translations

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a57d0f888323aff3672bbfed8235